### PR TITLE
Mb count qubit probability

### DIFF
--- a/dotBloch/Assets/Classes/Constants.cs
+++ b/dotBloch/Assets/Classes/Constants.cs
@@ -7,6 +7,11 @@
         public const string quantum_zero = " |0> ";      
     }
 
+    public static class quantum_probability{
+        public const string zero_label = "P(|0>) = ";
+        public const string one_label = "P(|1>) = ";
+    }
+
     public static class error{
         public const string angle_is_wrong = "Value of theta or phi angle is wrong";
     }
@@ -15,6 +20,8 @@
         public const string space = " ";
         public const string dot = ".";
         public const string comma = ",";
+
+        public const string percent = "%";
 
         public const string rounding_header = "N";
     }

--- a/dotBloch/Assets/Classes/PrintQubit.cs
+++ b/dotBloch/Assets/Classes/PrintQubit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using UnityEngine;
 using static PrintBlochSettings;
 
 public class PrintQubit
@@ -50,6 +51,32 @@ public class PrintQubit
     private bool not_added(PrintBlochSettings settings){
         return settings == null ? true : false;
     }
+
+    public string percent_value(bool is_zero,double value, PrintBlochSettings printingSettings = null)
+    {
+        string result = String.Empty;
+        PrintBlochSettings printing_rules = set_printing_rules(ref printingSettings);
+
+        Debug.Log("Printing rules: " + printing_rules);
+
+        if(is_zero)
+            result += Constants.quantum_probability.zero_label;
+        else
+            result += Constants.quantum_probability.one_label;
+
+        value *= 100;
+        value = Math.Round(value,3);
+        result += value.ToString();
+
+        result += Constants.character.percent;
+
+        result = remove_spaces_if_needed(result,printing_rules.printSpaces);
+        Debug.Log("Decimal separator: " + printing_rules.decimalSeparator);
+        result = set_decimal_separator(result,printing_rules.decimalSeparator);
+        return result;
+    }
+
+
 
     public string quantum_value(Complex number,PrintBlochSettings printingSettings = null){
         string result = String.Empty;

--- a/dotBloch/Assets/Classes/PrintQubit.cs
+++ b/dotBloch/Assets/Classes/PrintQubit.cs
@@ -57,8 +57,6 @@ public class PrintQubit
         string result = String.Empty;
         PrintBlochSettings printing_rules = set_printing_rules(ref printingSettings);
 
-        Debug.Log("Printing rules: " + printing_rules);
-
         if(is_zero)
             result += Constants.quantum_probability.zero_label;
         else
@@ -71,7 +69,6 @@ public class PrintQubit
         result += Constants.character.percent;
 
         result = remove_spaces_if_needed(result,printing_rules.printSpaces);
-        Debug.Log("Decimal separator: " + printing_rules.decimalSeparator);
         result = set_decimal_separator(result,printing_rules.decimalSeparator);
         return result;
     }

--- a/dotBloch/Assets/Classes/PrintQubit.cs
+++ b/dotBloch/Assets/Classes/PrintQubit.cs
@@ -65,7 +65,7 @@ public class PrintQubit
             result += Constants.quantum_probability.one_label;
 
         value *= 100;
-        value = Math.Round(value,3);
+        value = Math.Round(value,printing_rules.decimalSpaces);
         result += value.ToString();
 
         result += Constants.character.percent;

--- a/dotBloch/Assets/Classes/Qubit.cs
+++ b/dotBloch/Assets/Classes/Qubit.cs
@@ -137,35 +137,12 @@ public class Qubit
 
     public string print_zero_probability(PrintBlochSettings printingSettings = null)
     {
-        string result = "";
-
-        result += Constants.quantum_probability.zero_label;
-
-        double value = this.probability[0];
-        value *= 100;
-        value = Math.Round(value,3);
-
-        result += value.ToString();
-
-        result += Constants.character.percent;
-
-        return result;
+        return print.percent_value(true,probability[0],printingSettings);
     }
 
     public string print_one_probability(PrintBlochSettings printingSettings = null)
     {
-        string result = "";
-
-        result += Constants.quantum_probability.one_label;
-        double value = this.probability[1];
-        value *= 100;
-        value = Math.Round(value,3);
-
-        result += value.ToString();
-
-        result += Constants.character.percent;
-
-        return result;
+        return print.percent_value(false,probability[1],printingSettings);
     }
 #endregion
 }

--- a/dotBloch/Assets/Classes/Qubit.cs
+++ b/dotBloch/Assets/Classes/Qubit.cs
@@ -10,7 +10,7 @@ public class Qubit
 
     private Complex[] quantumValue = new Complex[2];
     private Complex[,] density_matrix = new Complex[2,2];
-    private Complex[,] probability = new Complex[2,2];
+    private double[] probability = new double[2];
 
     public Qubit(double thetaAngle, double phiAngle)
     {
@@ -95,8 +95,25 @@ public class Qubit
 
     private void update_probability()
     {
+        double theta_angle = StaticMethods.degree_to_radian(this.thetaAngle);
+        double phi_angle = StaticMethods.degree_to_radian(this.phiAngle);
 
+        Complex alfa = new Complex(Math.Cos(phi_angle)*Math.Cos(theta_angle/2),Math.Sin(phi_angle)*Math.Cos(theta_angle/2));
+        Debug.Log("alfa: " + alfa);
+        Complex beta = new Complex(Math.Cos(theta_angle+phi_angle)*Math.Sin(theta_angle/2),Math.Sin(theta_angle+phi_angle)*Math.Sin(theta_angle/2));
+        Debug.Log("beta: " + beta);
+
+        alfa = Complex.Multiply(alfa,alfa);
+        Debug.Log("alfa^2: " + alfa);
+        beta = Complex.Multiply(beta,beta);
+        Debug.Log("beta^2: " + beta);
+
+        this.probability[0] = Convert.ToDouble(alfa.Magnitude/(alfa.Magnitude+beta.Magnitude));
+        Debug.Log("probability[0]: " + this.probability[0]);
+        this.probability[1] = Convert.ToDouble(beta.Magnitude/(alfa.Magnitude+beta.Magnitude));
+        Debug.Log("probability[1]: " + this.probability[1]);
     }
+
 
 #endregion
 
@@ -120,12 +137,12 @@ public class Qubit
 
     public string print_zero_probability(PrintBlochSettings printingSettings = null)
     {
-        throw new NotImplementedException();
+        return this.probability[0].ToString();
     }
 
     public string print_one_probability(PrintBlochSettings printingSettings = null)
     {
-        throw new NotImplementedException();
+        return this.probability[1].ToString();
     }
 #endregion
 }

--- a/dotBloch/Assets/Classes/Qubit.cs
+++ b/dotBloch/Assets/Classes/Qubit.cs
@@ -99,19 +99,13 @@ public class Qubit
         double phi_angle = StaticMethods.degree_to_radian(this.phiAngle);
 
         Complex alfa = new Complex(Math.Cos(phi_angle)*Math.Cos(theta_angle/2),Math.Sin(phi_angle)*Math.Cos(theta_angle/2));
-        Debug.Log("alfa: " + alfa);
         Complex beta = new Complex(Math.Cos(theta_angle+phi_angle)*Math.Sin(theta_angle/2),Math.Sin(theta_angle+phi_angle)*Math.Sin(theta_angle/2));
-        Debug.Log("beta: " + beta);
 
         alfa = Complex.Multiply(alfa,alfa);
-        Debug.Log("alfa^2: " + alfa);
         beta = Complex.Multiply(beta,beta);
-        Debug.Log("beta^2: " + beta);
 
         this.probability[0] = Convert.ToDouble(alfa.Magnitude/(alfa.Magnitude+beta.Magnitude));
-        Debug.Log("probability[0]: " + this.probability[0]);
         this.probability[1] = Convert.ToDouble(beta.Magnitude/(alfa.Magnitude+beta.Magnitude));
-        Debug.Log("probability[1]: " + this.probability[1]);
     }
 
 

--- a/dotBloch/Assets/Classes/Qubit.cs
+++ b/dotBloch/Assets/Classes/Qubit.cs
@@ -137,12 +137,35 @@ public class Qubit
 
     public string print_zero_probability(PrintBlochSettings printingSettings = null)
     {
-        return this.probability[0].ToString();
+        string result = "";
+
+        result += Constants.quantum_probability.zero_label;
+
+        double value = this.probability[0];
+        value *= 100;
+        value = Math.Round(value,3);
+
+        result += value.ToString();
+
+        result += Constants.character.percent;
+
+        return result;
     }
 
     public string print_one_probability(PrintBlochSettings printingSettings = null)
     {
-        return this.probability[1].ToString();
+        string result = "";
+
+        result += Constants.quantum_probability.one_label;
+        double value = this.probability[1];
+        value *= 100;
+        value = Math.Round(value,3);
+
+        result += value.ToString();
+
+        result += Constants.character.percent;
+
+        return result;
     }
 #endregion
 }

--- a/dotBloch/Assets/Classes/Qubit.cs
+++ b/dotBloch/Assets/Classes/Qubit.cs
@@ -10,6 +10,7 @@ public class Qubit
 
     private Complex[] quantumValue = new Complex[2];
     private Complex[,] density_matrix = new Complex[2,2];
+    private Complex[,] probability = new Complex[2,2];
 
     public Qubit(double thetaAngle, double phiAngle)
     {
@@ -20,6 +21,7 @@ public class Qubit
             this.update_quantum_zero_value();
             this.update_quantum_one_value();
             this.update_density_matrix();
+            this.update_probability();
 
             this.print = new PrintQubit();
         }
@@ -44,6 +46,7 @@ public class Qubit
                 _phiAngle = value;
                 this.update_quantum_one_value();
                 this.update_density_matrix();
+                this.update_probability();
             }
             else{
                 Debug.Log(Constants.error.angle_is_wrong);
@@ -64,6 +67,7 @@ public class Qubit
                 this.update_quantum_zero_value();
                 this.update_quantum_one_value();
                 this.update_density_matrix();
+                this.update_probability();
             }
         }
     }
@@ -89,10 +93,16 @@ public class Qubit
         density_matrix[1,1] = new Complex(Math.Pow(Math.Sin(StaticMethods.degree_to_radian(this._thetaAngle)/2),2),0);
     }
 
+    private void update_probability()
+    {
+
+    }
+
 #endregion
 
 #region printing
-    public string print_bloch_vector(PrintBlochSettings printingSettings = null){
+    public string print_bloch_vector(PrintBlochSettings printingSettings = null)
+    {
         return print.bloch_vector(this.quantumValue,printingSettings);
     }
     
@@ -106,6 +116,16 @@ public class Qubit
 
     public string printDensityMatrix(int row, int column, PrintBlochSettings printingSettings = null){
         return print.quantum_value(density_matrix[row,column],printingSettings);
+    }
+
+    public string print_zero_probability(PrintBlochSettings printingSettings = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public string print_one_probability(PrintBlochSettings printingSettings = null)
+    {
+        throw new NotImplementedException();
     }
 #endregion
 }

--- a/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
+++ b/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
@@ -22,12 +22,16 @@ namespace Tests
             quantumBit.thetaAngle = 0;
             quantumBit.phiAngle = 0;
             
+            Assert.AreEqual("P(|0>) = 100%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 0%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_0_phi_45_Tests(){
             quantumBit = new Qubit(0,45);
             
+            Assert.AreEqual("P(|0>) = 100%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 0%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -36,12 +40,16 @@ namespace Tests
             quantumBit.thetaAngle = 0;
             quantumBit.phiAngle = 90;
             
+            Assert.AreEqual("P(|0>) = 100%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 0%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_0_phi_180_Tests(){
             quantumBit = new Qubit(0,180);
-            
+
+            Assert.AreEqual("P(|0>) = 100%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 0%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -50,12 +58,16 @@ namespace Tests
             quantumBit.thetaAngle = 0;
             quantumBit.phiAngle = 270;
             
+            Assert.AreEqual("P(|0>) = 100%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 0%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_0_phi_359_Tests(){
             quantumBit = new Qubit(0,359);
             
+            Assert.AreEqual("P(|0>) = 100%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 0%", quantumBit.print_one_probability());
         }
         
         [Test]
@@ -64,6 +76,8 @@ namespace Tests
             quantumBit.thetaAngle = 0;
             quantumBit.phiAngle = 360;
             
+            Assert.AreEqual("P(|0>) = 100%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 0%", quantumBit.print_one_probability());
         }
         #endregion
 
@@ -74,12 +88,16 @@ namespace Tests
             quantumBit.thetaAngle = 30;
             quantumBit.phiAngle = 0;
             
+            Assert.AreEqual("P(|0>) = 93,301%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 6,699%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_30_phi_45_Tests(){
             quantumBit = new Qubit(30,45);
 
+            Assert.AreEqual("P(|0>) = 93,301%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 6,699%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -88,12 +106,16 @@ namespace Tests
             quantumBit.thetaAngle = 30;
             quantumBit.phiAngle = 90;
 
+            Assert.AreEqual("P(|0>) = 93,301%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 6,699%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_30_phi_180_Tests(){
             quantumBit = new Qubit(30,180);
 
+            Assert.AreEqual("P(|0>) = 93,301%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 6,699%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -102,12 +124,16 @@ namespace Tests
             quantumBit.thetaAngle = 30;
             quantumBit.phiAngle = 270;
 
+            Assert.AreEqual("P(|0>) = 93,301%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 6,699%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_30_phi_359_Tests(){
             quantumBit = new Qubit(30,359);
 
+            Assert.AreEqual("P(|0>) = 93,301%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 6,699%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -116,6 +142,8 @@ namespace Tests
             quantumBit.thetaAngle = 30;
             quantumBit.phiAngle = 360;
 
+            Assert.AreEqual("P(|0>) = 93,301%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 6,699%", quantumBit.print_one_probability());
         }
         #endregion
 
@@ -126,12 +154,16 @@ namespace Tests
             quantumBit.thetaAngle = 45;
             quantumBit.phiAngle = 0;
 
+            Assert.AreEqual("P(|0>) = 85,355%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 14,645%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_45_phi_45_Tests(){
             quantumBit = new Qubit(45,45);
-
+            
+            Assert.AreEqual("P(|0>) = 85,355%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 14,645%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -140,12 +172,16 @@ namespace Tests
             quantumBit.thetaAngle = 45;
             quantumBit.phiAngle = 90;
 
+            Assert.AreEqual("P(|0>) = 85,355%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 14,645%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_45_phi_180_Tests(){
             quantumBit = new Qubit(45,180);
-
+            
+            Assert.AreEqual("P(|0>) = 85,355%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 14,645%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -154,12 +190,16 @@ namespace Tests
             quantumBit.thetaAngle = 45;
             quantumBit.phiAngle = 270;
 
+            Assert.AreEqual("P(|0>) = 85,355%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 14,645%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_45_phi_359_Tests(){
             quantumBit = new Qubit(45,359);
 
+            Assert.AreEqual("P(|0>) = 85,355%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 14,645%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -167,7 +207,9 @@ namespace Tests
             quantumBit = new Qubit(0,0);
             quantumBit.thetaAngle = 45;
             quantumBit.phiAngle = 360;
-
+            
+            Assert.AreEqual("P(|0>) = 85,355%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 14,645%", quantumBit.print_one_probability());
         }
         #endregion
 
@@ -178,12 +220,16 @@ namespace Tests
             quantumBit.thetaAngle = 60;
             quantumBit.phiAngle = 0;
 
+            Assert.AreEqual("P(|0>) = 75%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 25%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_60_phi_45_Tests(){
             quantumBit = new Qubit(60,45);
-
+            
+            Assert.AreEqual("P(|0>) = 75%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 25%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -192,12 +238,16 @@ namespace Tests
             quantumBit.thetaAngle = 60;
             quantumBit.phiAngle = 90;
 
+            Assert.AreEqual("P(|0>) = 75%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 25%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_60_phi_180_Tests(){
             quantumBit = new Qubit(60,180);
 
+            Assert.AreEqual("P(|0>) = 75%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 25%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -205,13 +255,17 @@ namespace Tests
             quantumBit = new Qubit(0,0);
             quantumBit.thetaAngle = 60;
             quantumBit.phiAngle = 270;
-
-        }
+            
+            Assert.AreEqual("P(|0>) = 75%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 25%", quantumBit.print_one_probability());
+        }  
 
         [Test]
         public void theta_60_phi_359_Tests(){
             quantumBit = new Qubit(60,359);
 
+            Assert.AreEqual("P(|0>) = 75%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 25%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -220,6 +274,8 @@ namespace Tests
             quantumBit.thetaAngle = 60;
             quantumBit.phiAngle = 360;
 
+            Assert.AreEqual("P(|0>) = 75%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 25%", quantumBit.print_one_probability());
         }
         #endregion
 
@@ -230,12 +286,16 @@ namespace Tests
             quantumBit.thetaAngle = 90;
             quantumBit.phiAngle = 0;
 
+            Assert.AreEqual("P(|0>) = 50%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 50%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_90_phi_45_Tests(){
             quantumBit = new Qubit(90,45);
 
+            Assert.AreEqual("P(|0>) = 50%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 50%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -244,11 +304,15 @@ namespace Tests
             quantumBit.thetaAngle = 90;
             quantumBit.phiAngle = 90;
 
+            Assert.AreEqual("P(|0>) = 50%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 50%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_90_phi_180_Tests(){
             quantumBit = new Qubit(90,180);
+            Assert.AreEqual("P(|0>) = 50%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 50%", quantumBit.print_one_probability());
 
         }
 
@@ -258,12 +322,16 @@ namespace Tests
             quantumBit.thetaAngle = 90;
             quantumBit.phiAngle = 270;
 
+            Assert.AreEqual("P(|0>) = 50%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 50%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_90_phi_359_Tests(){
             quantumBit = new Qubit(90,359);
 
+            Assert.AreEqual("P(|0>) = 50%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 50%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -272,6 +340,8 @@ namespace Tests
             quantumBit.thetaAngle = 90;
             quantumBit.phiAngle = 360;
 
+            Assert.AreEqual("P(|0>) = 50%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 50%", quantumBit.print_one_probability());
         }
         #endregion
 
@@ -282,12 +352,16 @@ namespace Tests
             quantumBit.thetaAngle = 120;
             quantumBit.phiAngle = 0;
 
+            Assert.AreEqual("P(|0>) = 25%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 75%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_120_phi_45_Tests(){
             quantumBit = new Qubit(120,45);
 
+            Assert.AreEqual("P(|0>) = 25%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 75%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -296,12 +370,16 @@ namespace Tests
             quantumBit.thetaAngle = 120;
             quantumBit.phiAngle = 90;
 
+            Assert.AreEqual("P(|0>) = 25%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 75%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_120_phi_180_Tests(){
             quantumBit = new Qubit(120,180);
 
+            Assert.AreEqual("P(|0>) = 25%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 75%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -310,12 +388,16 @@ namespace Tests
             quantumBit.thetaAngle = 120;
             quantumBit.phiAngle = 270;
 
+            Assert.AreEqual("P(|0>) = 25%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 75%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_120_phi_359_Tests(){
             quantumBit = new Qubit(120,359);
 
+            Assert.AreEqual("P(|0>) = 25%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 75%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -324,6 +406,8 @@ namespace Tests
             quantumBit.thetaAngle = 120;
             quantumBit.phiAngle = 360;
 
+            Assert.AreEqual("P(|0>) = 25%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 75%", quantumBit.print_one_probability());
         }
         #endregion
 
@@ -334,12 +418,16 @@ namespace Tests
             quantumBit.thetaAngle = 180;
             quantumBit.phiAngle = 0;
 
+            Assert.AreEqual("P(|0>) = 0%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_180_phi_45_Tests(){
             quantumBit = new Qubit(180,45);
 
+            Assert.AreEqual("P(|0>) = 0%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -348,12 +436,16 @@ namespace Tests
             quantumBit.thetaAngle = 180;
             quantumBit.phiAngle = 90;
 
+            Assert.AreEqual("P(|0>) = 0%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_180_phi_180_Tests(){
             quantumBit = new Qubit(180,180);
 
+            Assert.AreEqual("P(|0>) = 0%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -362,12 +454,16 @@ namespace Tests
             quantumBit.thetaAngle = 180;
             quantumBit.phiAngle = 270;
 
+            Assert.AreEqual("P(|0>) = 0%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
 
         [Test]
         public void theta_180_phi_359_Tests(){
             quantumBit = new Qubit(180,359);
 
+            Assert.AreEqual("P(|0>) = 0%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
 
         [Test]
@@ -376,6 +472,8 @@ namespace Tests
             quantumBit.thetaAngle = 180;
             quantumBit.phiAngle = 360;
 
+            Assert.AreEqual("P(|0>) = 0%", quantumBit.print_zero_probability());
+            Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
         #endregion
     }

--- a/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
+++ b/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
@@ -476,5 +476,29 @@ namespace Tests
             Assert.AreEqual("P(|1>) = 100%", quantumBit.print_one_probability());
         }
         #endregion
+    
+        #region custom_printing
+
+        [Test]
+        public void custom_settings_theta_45_phi_45_with_cutsom_settings_1_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 45;
+            quantumBit.phiAngle = 45;
+            PrintBlochSettings settings = new PrintBlochSettings(true,false,2,PrintBlochSettings.DecimalSeparator.dot,PrintBlochSettings.ImaginaryUnit.I);
+            Assert.AreEqual("P(|0>) = 85.36%", quantumBit.print_zero_probability(settings));
+            Assert.AreEqual("P(|1>) = 14.64%", quantumBit.print_one_probability(settings));
+        }
+
+        [Test]
+        public void custom_settings_theta_45_phi_45_with_cutsom_settings_2_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 45;
+            quantumBit.phiAngle = 45;
+            PrintBlochSettings settings = new PrintBlochSettings(false,false,1,PrintBlochSettings.DecimalSeparator.comma,PrintBlochSettings.ImaginaryUnit.j); 
+            Assert.AreEqual("P(|0>)=85,4%", quantumBit.print_zero_probability(settings));
+            Assert.AreEqual("P(|1>)=14,6%", quantumBit.print_one_probability(settings));
+        }
+
+        #endregion
     }
 }

--- a/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
+++ b/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
@@ -480,6 +480,16 @@ namespace Tests
         #region custom_printing
 
         [Test]
+        public void custom_settings_theta_90_phi_180_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 90;
+            quantumBit.phiAngle = 180;
+            PrintBlochSettings settings = new PrintBlochSettings(false,false,0,PrintBlochSettings.DecimalSeparator.comma,PrintBlochSettings.ImaginaryUnit.J);
+            Assert.AreEqual("P(|0>)=50%", quantumBit.print_zero_probability(settings));
+            Assert.AreEqual("P(|1>)=50%", quantumBit.print_one_probability(settings));
+        }
+
+        [Test]
         public void custom_settings_theta_45_phi_45_with_cutsom_settings_1_Test(){
             quantumBit = new Qubit(0,0);
             quantumBit.thetaAngle = 45;
@@ -497,6 +507,16 @@ namespace Tests
             PrintBlochSettings settings = new PrintBlochSettings(false,false,1,PrintBlochSettings.DecimalSeparator.comma,PrintBlochSettings.ImaginaryUnit.j); 
             Assert.AreEqual("P(|0>)=85,4%", quantumBit.print_zero_probability(settings));
             Assert.AreEqual("P(|1>)=14,6%", quantumBit.print_one_probability(settings));
+        }
+
+        [Test]
+        public void custom_settings_theta_45_phi_45_with_cutsom_settings_3_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 45;
+            quantumBit.phiAngle = 45;
+            PrintBlochSettings settings = new PrintBlochSettings(false,false,0,PrintBlochSettings.DecimalSeparator.comma,PrintBlochSettings.ImaginaryUnit.j); 
+            Assert.AreEqual("P(|0>)=85%", quantumBit.print_zero_probability(settings));
+            Assert.AreEqual("P(|1>)=15%", quantumBit.print_one_probability(settings));
         }
 
         #endregion

--- a/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
+++ b/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs
@@ -1,0 +1,382 @@
+﻿using System.Diagnostics;
+using NUnit.Framework;
+using static PrintBlochSettings;
+
+namespace Tests
+{
+    public class print_quantum_probability
+    {
+        Qubit quantumBit;
+
+        [Test]
+        public void nUnit_Tests()
+        {
+            Assert.AreEqual(true, true);
+            Assert.AreEqual(null, null);
+        }    
+
+        #region theta_0
+        [Test]
+        public void theta_0_phi_0_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 0;
+            quantumBit.phiAngle = 0;
+            
+        }
+
+        [Test]
+        public void theta_0_phi_45_Tests(){
+            quantumBit = new Qubit(0,45);
+            
+        }
+
+        [Test]
+        public void theta_0_phi_90_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 0;
+            quantumBit.phiAngle = 90;
+            
+        }
+
+        [Test]
+        public void theta_0_phi_180_Tests(){
+            quantumBit = new Qubit(0,180);
+            
+        }
+
+        [Test]
+        public void theta_0_phi_270_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 0;
+            quantumBit.phiAngle = 270;
+            
+        }
+
+        [Test]
+        public void theta_0_phi_359_Tests(){
+            quantumBit = new Qubit(0,359);
+            
+        }
+        
+        [Test]
+        public void theta_0_phi_360_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 0;
+            quantumBit.phiAngle = 360;
+            
+        }
+        #endregion
+
+        #region theta_30
+        [Test]
+        public void theta_30_phi_0_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 30;
+            quantumBit.phiAngle = 0;
+            
+        }
+
+        [Test]
+        public void theta_30_phi_45_Tests(){
+            quantumBit = new Qubit(30,45);
+
+        }
+
+        [Test]
+        public void theta_30_phi_90_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 30;
+            quantumBit.phiAngle = 90;
+
+        }
+
+        [Test]
+        public void theta_30_phi_180_Tests(){
+            quantumBit = new Qubit(30,180);
+
+        }
+
+        [Test]
+        public void theta_30_phi_270_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 30;
+            quantumBit.phiAngle = 270;
+
+        }
+
+        [Test]
+        public void theta_30_phi_359_Tests(){
+            quantumBit = new Qubit(30,359);
+
+        }
+
+        [Test]
+        public void theta_30_phi_360_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 30;
+            quantumBit.phiAngle = 360;
+
+        }
+        #endregion
+
+        #region theeta_45
+        [Test]
+        public void theta_45_phi_0_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 45;
+            quantumBit.phiAngle = 0;
+
+        }
+
+        [Test]
+        public void theta_45_phi_45_Tests(){
+            quantumBit = new Qubit(45,45);
+
+        }
+
+        [Test]
+        public void theta_45_phi_90_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 45;
+            quantumBit.phiAngle = 90;
+
+        }
+
+        [Test]
+        public void theta_45_phi_180_Tests(){
+            quantumBit = new Qubit(45,180);
+
+        }
+
+        [Test]
+        public void theta_45_phi_270_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 45;
+            quantumBit.phiAngle = 270;
+
+        }
+
+        [Test]
+        public void theta_45_phi_359_Tests(){
+            quantumBit = new Qubit(45,359);
+
+        }
+
+        [Test]
+        public void theta_45_phi_360_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 45;
+            quantumBit.phiAngle = 360;
+
+        }
+        #endregion
+
+        #region theta_60
+        [Test]
+        public void theta_60_phi_0_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 60;
+            quantumBit.phiAngle = 0;
+
+        }
+
+        [Test]
+        public void theta_60_phi_45_Tests(){
+            quantumBit = new Qubit(60,45);
+
+        }
+
+        [Test]
+        public void theta_60_phi_90_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 60;
+            quantumBit.phiAngle = 90;
+
+        }
+
+        [Test]
+        public void theta_60_phi_180_Tests(){
+            quantumBit = new Qubit(60,180);
+
+        }
+
+        [Test]
+        public void theta_60_phi_270_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 60;
+            quantumBit.phiAngle = 270;
+
+        }
+
+        [Test]
+        public void theta_60_phi_359_Tests(){
+            quantumBit = new Qubit(60,359);
+
+        }
+
+        [Test]
+        public void theta_60_phi_360_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 60;
+            quantumBit.phiAngle = 360;
+
+        }
+        #endregion
+
+        #region theta_90
+        [Test]
+        public void theta_90_phi_0_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 90;
+            quantumBit.phiAngle = 0;
+
+        }
+
+        [Test]
+        public void theta_90_phi_45_Tests(){
+            quantumBit = new Qubit(90,45);
+
+        }
+
+        [Test]
+        public void theta_90_phi_90_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 90;
+            quantumBit.phiAngle = 90;
+
+        }
+
+        [Test]
+        public void theta_90_phi_180_Tests(){
+            quantumBit = new Qubit(90,180);
+
+        }
+
+        [Test]
+        public void theta_90_phi_270_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 90;
+            quantumBit.phiAngle = 270;
+
+        }
+
+        [Test]
+        public void theta_90_phi_359_Tests(){
+            quantumBit = new Qubit(90,359);
+
+        }
+
+        [Test]
+        public void theta_90_phi_360_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 90;
+            quantumBit.phiAngle = 360;
+
+        }
+        #endregion
+
+        #region theta_120
+        [Test]
+        public void theta_120_phi_0_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 120;
+            quantumBit.phiAngle = 0;
+
+        }
+
+        [Test]
+        public void theta_120_phi_45_Tests(){
+            quantumBit = new Qubit(120,45);
+
+        }
+
+        [Test]
+        public void theta_120_phi_90_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 120;
+            quantumBit.phiAngle = 90;
+
+        }
+
+        [Test]
+        public void theta_120_phi_180_Tests(){
+            quantumBit = new Qubit(120,180);
+
+        }
+
+        [Test]
+        public void theta_120_phi_270_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 120;
+            quantumBit.phiAngle = 270;
+
+        }
+
+        [Test]
+        public void theta_120_phi_359_Tests(){
+            quantumBit = new Qubit(120,359);
+
+        }
+
+        [Test]
+        public void theta_120_phi_360_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 120;
+            quantumBit.phiAngle = 360;
+
+        }
+        #endregion
+
+        #region theta_180
+        [Test]
+        public void theta_180_phi_0_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 180;
+            quantumBit.phiAngle = 0;
+
+        }
+
+        [Test]
+        public void theta_180_phi_45_Tests(){
+            quantumBit = new Qubit(180,45);
+
+        }
+
+        [Test]
+        public void theta_180_phi_90_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 180;
+            quantumBit.phiAngle = 90;
+
+        }
+
+        [Test]
+        public void theta_180_phi_180_Tests(){
+            quantumBit = new Qubit(180,180);
+
+        }
+
+        [Test]
+        public void theta_180_phi_270_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 180;
+            quantumBit.phiAngle = 270;
+
+        }
+
+        [Test]
+        public void theta_180_phi_359_Tests(){
+            quantumBit = new Qubit(180,359);
+
+        }
+
+        [Test]
+        public void theta_180_phi_360_Test(){
+            quantumBit = new Qubit(0,0);
+            quantumBit.thetaAngle = 180;
+            quantumBit.phiAngle = 360;
+
+        }
+        #endregion
+    }
+}

--- a/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs.meta
+++ b/dotBloch/Assets/Classes/Tests/print_quantum_probability.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7947ca310fd44b14bfd836a0a5d8f45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotBloch/Assets/mainScene.unity
+++ b/dotBloch/Assets/mainScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0.99999946, b: 0.99999946, a: 1}
+  m_IndirectSpecularColor: {r: 0.009872444, g: 0.085798495, b: 0.2186622, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -4143,6 +4143,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Layer
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7332300868423908867, guid: fcc23280d0a16447284aca3ac69ac7ef,
+        type: 3}
+      propertyPath: m_Text
+      value: "|0> \u2248 75,YYY %"
       objectReference: {fileID: 0}
     - target: {fileID: 7332300868434157714, guid: fcc23280d0a16447284aca3ac69ac7ef,
         type: 3}

--- a/dotBloch/ProjectSettings/EditorSettings.asset
+++ b/dotBloch/ProjectSettings/EditorSettings.asset
@@ -3,19 +3,33 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 9
   m_ExternalVersionControlSupport: Visible Meta Files
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 2
   m_DefaultBehaviorMode: 0
+  m_PrefabRegularEnvironment: {fileID: 0}
+  m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
   m_SpritePackerPaddingPower: 1
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmref
   m_ProjectGenerationRootNamespace: 
-  m_UserGeneratedProjectSuffix: 
   m_CollabEditorSettings:
     inProgressEnabled: 1
+  m_EnableTextureStreamingInEditMode: 1
+  m_EnableTextureStreamingInPlayMode: 1
+  m_AsyncShaderCompilation: 1
+  m_EnterPlayModeOptionsEnabled: 0
+  m_EnterPlayModeOptions: 3
+  m_ShowLightmapResolutionOverlay: 1
+  m_UseLegacyProbeSampleCount: 1
+  m_AssetPipelineMode: 1
+  m_CacheServerMode: 0
+  m_CacheServerEndpoint: 
+  m_CacheServerNamespacePrefix: default
+  m_CacheServerEnableDownload: 1
+  m_CacheServerEnableUpload: 1


### PR DESCRIPTION
Getting percentage of |0> and |1> values. I implemented it only as part of the Qubit class and covered it with unit tests. Values are not being displayed yet. We will add them to the code on the next refactoring meeting after merging all the branches (to avoid conflicts on mainScene).

Please check the code and make sure sure that you can run all unit tests without errors.

Running nUnit in Unity:
- Window >> General >> Test Runner