### PR TITLE
Marcinbogiel/quantum probability transparency

### DIFF
--- a/dotBloch/Assets/Classes/Qubit.cs
+++ b/dotBloch/Assets/Classes/Qubit.cs
@@ -54,6 +54,14 @@ public class Qubit
         }
     }
 
+    public double this[int index]
+    {
+        get
+        {
+            return probability[index];
+        }
+    }
+
     public double thetaAngle
     {
         get

--- a/dotBloch/Assets/mainScene.unity
+++ b/dotBloch/Assets/mainScene.unity
@@ -4165,6 +4165,11 @@ PrefabInstance:
       propertyPath: m_Text
       value: P(|0>) = 75,YYY %
       objectReference: {fileID: 0}
+    - target: {fileID: 7332300868423908867, guid: fcc23280d0a16447284aca3ac69ac7ef,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0.78431374
+      objectReference: {fileID: 0}
     - target: {fileID: 7332300868434157714, guid: fcc23280d0a16447284aca3ac69ac7ef,
         type: 3}
       propertyPath: m_Layer
@@ -4190,6 +4195,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Text
       value: P(|1>) = 25,YYY %
+      objectReference: {fileID: 0}
+    - target: {fileID: 7332300868434157716, guid: fcc23280d0a16447284aca3ac69ac7ef,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0.3137255
       objectReference: {fileID: 0}
     - target: {fileID: 7332300869211952330, guid: fcc23280d0a16447284aca3ac69ac7ef,
         type: 3}

--- a/dotBloch/Assets/mainScene.unity
+++ b/dotBloch/Assets/mainScene.unity
@@ -4168,7 +4168,7 @@ PrefabInstance:
     - target: {fileID: 7332300868423908867, guid: fcc23280d0a16447284aca3ac69ac7ef,
         type: 3}
       propertyPath: m_Color.a
-      value: 0.78431374
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7332300868434157714, guid: fcc23280d0a16447284aca3ac69ac7ef,
         type: 3}
@@ -4199,7 +4199,7 @@ PrefabInstance:
     - target: {fileID: 7332300868434157716, guid: fcc23280d0a16447284aca3ac69ac7ef,
         type: 3}
       propertyPath: m_Color.a
-      value: 0.3137255
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7332300869211952330, guid: fcc23280d0a16447284aca3ac69ac7ef,
         type: 3}

--- a/dotBloch/Assets/mainScript.cs
+++ b/dotBloch/Assets/mainScript.cs
@@ -102,6 +102,8 @@ public class mainScript : MonoBehaviour {
 			propabilityOne.text = this.quantumBit.print_one_probability();
 			propabilityZero.text = this.quantumBit.print_zero_probability();
 
+			this.setTransparencyOfQuantumProbabilityLabels(quantumBit);
+
 			qubitLabel.text = this.quantumBit.print_bloch_vector();
 		} else if (bitValue) { 
 			this.thetaInputField.text = "1";
@@ -201,5 +203,12 @@ public class mainScript : MonoBehaviour {
 	private void open_exit_panel(){
 		ExitPanel.SetActive(true);
 		ExitText.text = Constants.message.exit_question;
+	}
+
+	private void setTransparencyOfQuantumProbabilityLabels(Qubit quantumBit)
+	{
+		propabilityZero.color = new Color32(255,255,255,200);
+		propabilityOne.color = new Color32(255,255,255,80);
+		//propabilityZero.text = this.quantumBit.print_zero_probability();
 	}
 }

--- a/dotBloch/Assets/mainScript.cs
+++ b/dotBloch/Assets/mainScript.cs
@@ -207,10 +207,16 @@ public class mainScript : MonoBehaviour {
 
 	private void setTransparencyOfQuantumProbabilityLabels(Qubit quantumBit)
 	{
-		Debug.Log("|0> = " + quantumBit[0] );
-		Debug.Log("|1> = " + quantumBit[1] );
-		propabilityZero.color = new Color32(255,255,255,200);
-		propabilityOne.color = new Color32(255,255,255,80);
-		//propabilityZero.text = this.quantumBit.print_zero_probability();
+		//Debug.Log("|0> = " + quantumBit[0] );
+		//Debug.Log("|1> = " + quantumBit[1] );
+
+		byte zeroTransparency =  Convert.ToByte(80 + Math.Round(quantumBit[0]*120));
+		byte oneTransparency = Convert.ToByte(80 + Math.Round(quantumBit[1]*120));
+
+		Debug.Log("|0 transparency> = " + zeroTransparency);
+		Debug.Log("|1 transparency> = " + oneTransparency);
+
+		propabilityZero.color = new Color32(255,255,255,zeroTransparency);
+		propabilityOne.color = new Color32(255,255,255,oneTransparency);
 	}
 }

--- a/dotBloch/Assets/mainScript.cs
+++ b/dotBloch/Assets/mainScript.cs
@@ -207,6 +207,8 @@ public class mainScript : MonoBehaviour {
 
 	private void setTransparencyOfQuantumProbabilityLabels(Qubit quantumBit)
 	{
+		Debug.Log("|0> = " + quantumBit[0] );
+		Debug.Log("|1> = " + quantumBit[1] );
 		propabilityZero.color = new Color32(255,255,255,200);
 		propabilityOne.color = new Color32(255,255,255,80);
 		//propabilityZero.text = this.quantumBit.print_zero_probability();

--- a/dotBloch/Assets/mainScript.cs
+++ b/dotBloch/Assets/mainScript.cs
@@ -207,14 +207,8 @@ public class mainScript : MonoBehaviour {
 
 	private void setTransparencyOfQuantumProbabilityLabels(Qubit quantumBit)
 	{
-		//Debug.Log("|0> = " + quantumBit[0] );
-		//Debug.Log("|1> = " + quantumBit[1] );
-
 		byte zeroTransparency =  Convert.ToByte(80 + Math.Round(quantumBit[0]*120));
 		byte oneTransparency = Convert.ToByte(80 + Math.Round(quantumBit[1]*120));
-
-		Debug.Log("|0 transparency> = " + zeroTransparency);
-		Debug.Log("|1 transparency> = " + oneTransparency);
 
 		propabilityZero.color = new Color32(255,255,255,zeroTransparency);
 		propabilityOne.color = new Color32(255,255,255,oneTransparency);


### PR DESCRIPTION
Getting transparency for |0> and |1> values works! Please check the code and run it locally. You can also find current WebGL version [on development channel](https://approximates.github.io/Dev/) and Android on the Slack channel.