### PR TITLE
closing dialog on WebGL disabled

### DIFF
--- a/dotBloch/Assets/mainScript.cs
+++ b/dotBloch/Assets/mainScript.cs
@@ -201,8 +201,10 @@ public class mainScript : MonoBehaviour {
 
 
 	private void open_exit_panel(){
-		ExitPanel.SetActive(true);
-		ExitText.text = Constants.message.exit_question;
+		if (Application.platform != RuntimePlatform.WebGLPlayer){
+			ExitPanel.SetActive(true);
+			ExitText.text = Constants.message.exit_question;
+		}
 	}
 
 	private void setTransparencyOfQuantumProbabilityLabels(Qubit quantumBit)


### PR DESCRIPTION
Closing dialog has been disabled in WebGL version.
Checked in WebGL and Unity editor